### PR TITLE
Preserve original header casing which becomes exposed by getNames().

### DIFF
--- a/lib/Headers.js
+++ b/lib/Headers.js
@@ -4,6 +4,7 @@ var foldHeaderLine = require('./foldHeaderLine'),
     rfc2231 = require('rfc2231');
 
 function Headers(obj, doNotStringify) {
+    this.namesWithCase = {};
     this.valuesByName = {};
     this.populate(obj, doNotStringify);
 }
@@ -118,6 +119,9 @@ Headers.prototype.populateFromObject = function (valuesByName, doNotStringify) {
     Object.keys(valuesByName).forEach(function (headerName) {
         var value = valuesByName[headerName],
             headerNameLowerCase = headerName.toLowerCase();
+
+        this.namesWithCase[headerNameLowerCase] = headerName;
+
         if (Array.isArray(value)) {
             if (!doNotStringify) {
                 value = value.map(function (serializedHeaderValue) {
@@ -132,6 +136,7 @@ Headers.prototype.populateFromObject = function (valuesByName, doNotStringify) {
         } else if (typeof value === 'undefined' && !doNotStringify) {
             // Hmm, this might not behave as intended when the header occurs multiple times in the object with different casing
             delete this.valuesByName[headerNameLowerCase];
+            delete this.namesWithCase[headerNameLowerCase];
         } else {
             if (!doNotStringify) {
                 value = this.parseHeaderValue(value);
@@ -162,6 +167,12 @@ Headers.prototype.getAll = function (headerName) {
 };
 
 Headers.prototype.getNames = function () {
+    return Object.keys(this.valuesByName).map(function (lowerCaseHeaderName) {
+        return this.namesWithCase[lowerCaseHeaderName];
+    }, this);
+};
+
+Headers.prototype.getNamesLowerCase = function () {
     return Object.keys(this.valuesByName);
 };
 
@@ -181,12 +192,14 @@ Headers.prototype.set = function (headerName, valueOrValues, valueNumber) {
         }, this);
     } else {
         var headerNameLowerCase = headerName.toLowerCase();
+        this.namesWithCase[headerNameLowerCase] = headerName;
         if (Array.isArray(valueOrValues)) {
             if (typeof valueNumber !== 'undefined') {
                 throw new Error('Headers.set: valueNumber not supported when the values are provided as an array');
             }
             if (valueOrValues.length === 0) {
                 delete this.valuesByName[headerNameLowerCase];
+                delete this.namesWithCase[headerNameLowerCase];
             } else {
                 this.valuesByName[headerNameLowerCase] = valueOrValues.map(function (value) {
                     return this.parseHeaderValue(value);
@@ -214,6 +227,7 @@ Headers.prototype.remove = function (headerNameOrObj, valueOrValuesOrValueNumber
         return 0;
     } else if (typeof valueOrValuesOrValueNumber === 'undefined') {
         delete this.valuesByName[headerNameLowerCase];
+        delete this.namesWithCase[headerNameLowerCase];
         return values.length;
     } else if (Array.isArray(valueOrValuesOrValueNumber)) {
         valueOrValuesOrValueNumber.forEach(function (value) {
@@ -223,6 +237,7 @@ Headers.prototype.remove = function (headerNameOrObj, valueOrValuesOrValueNumber
     } else if (typeof valueOrValuesOrValueNumber === 'number') {
         if (values.length === 1 && valueOrValuesOrValueNumber === 0) {
             delete this.valuesByName[headerNameLowerCase];
+            delete this.namesWithCase[headerNameLowerCase];
             numRemoved = 1;
         } else if (valueOrValuesOrValueNumber < values.length) {
             values.splice(valueOrValuesOrValueNumber, 1);
@@ -234,6 +249,7 @@ Headers.prototype.remove = function (headerNameOrObj, valueOrValuesOrValueNumber
         if (index !== -1) {
             if (index === 0 && values.length === 1) {
                 delete this.valuesByName[headerNameLowerCase];
+                delete this.namesWithCase[headerNameLowerCase];
             } else {
                 values.splice(index, 1);
             }
@@ -323,8 +339,8 @@ Headers.prototype.equals = function (other) {
     if (this === other) {
         return true;
     }
-    var headerNames = this.getNames(),
-        otherHeaderNames = other.getNames();
+    var headerNames = this.getNamesLowerCase(),
+        otherHeaderNames = other.getNamesLowerCase();
     if (headerNames.length !== otherHeaderNames.length) {
         return false;
     }
@@ -358,8 +374,9 @@ Headers.prototype.equals = function (other) {
 };
 
 Headers.prototype.clone = function () {
-    var clone = new Headers();
-    this.getNames().forEach(function (headerName) {
+    var clone = new Headers(),
+        lowerCaseHeaderNames = this.getNamesLowerCase();
+    lowerCaseHeaderNames.forEach(function (headerName) {
         clone.set(headerName, this.getAll(headerName));
     }, this);
     return clone;
@@ -367,7 +384,7 @@ Headers.prototype.clone = function () {
 
 Headers.prototype.toString = function (maxLineLength) {
     var result = '',
-        lowerCaseHeaderNames = this.getNames();
+        lowerCaseHeaderNames = this.getNamesLowerCase();
     lowerCaseHeaderNames.forEach(function (lowerCaseHeaderName) {
         this.valuesByName[lowerCaseHeaderName].forEach(function (value) {
             result += formatHeaderName(lowerCaseHeaderName) + ': ' + foldHeaderLine(this.serializeHeaderValue(value), maxLineLength, maxLineLength - lowerCaseHeaderName.length - 2) + '\r\n';
@@ -377,16 +394,18 @@ Headers.prototype.toString = function (maxLineLength) {
 };
 
 Headers.prototype.toCanonicalObject = function () {
-    var canonicalObject = {};
-    this.getNames().forEach(function (lowerCaseHeaderName) {
+    var canonicalObject = {},
+        lowerCaseHeaderNames = this.getNamesLowerCase();
+    lowerCaseHeaderNames.forEach(function (lowerCaseHeaderName) {
         canonicalObject[formatHeaderName(lowerCaseHeaderName)] = this.getAll(lowerCaseHeaderName);
     }, this);
     return canonicalObject;
 };
 
 Headers.prototype.toJSON = function () {
-    var obj = {};
-    this.getNames().forEach(function (lowerCaseHeaderName) {
+    var obj = {},
+        lowerCaseHeaderNames = this.getNamesLowerCase();
+    lowerCaseHeaderNames.forEach(function (lowerCaseHeaderName) {
         var values = this.getAll(lowerCaseHeaderName);
         if (values.length === 1) {
             obj[formatHeaderName(lowerCaseHeaderName)] = this.get(lowerCaseHeaderName);

--- a/test/Headers.js
+++ b/test/Headers.js
@@ -51,6 +51,14 @@ describe('Headers', function () {
         expect(headers.toString(), 'to equal', 'Cookie: foo=bar\r\nCookie: quux=baz\r\n');
     });
 
+    it('should return the header names in their original case', function () {
+        expect(new Headers({'X-in-ORIGNAL-Case': 'baz'}).getNames(), 'to equal', ['X-in-ORIGNAL-Case']);
+    });
+
+    it('should return lower case header names when requested', function () {
+        expect(new Headers({'X-in-ORIGNAL-Case': 'baz'}).getNamesLowerCase(), 'to equal', ['x-in-orignal-case']);
+    });
+
     describe('#remove', function () {
         it('should remove all header values for the given header when only passed one argument', function () {
             var headers = new Headers({foo: ['bla', 'bar'], quux: 'baz'});

--- a/test/Message.js
+++ b/test/Message.js
@@ -23,7 +23,8 @@ describe('Message', function () {
 
     it('should parse the headers from the input', function () {
         var message = new Message('From: thisguy@example.com\r\nTo: thisotherguy@example.com');
-        expect(message.headers.getNames(), 'to equal', ['from', 'to']);
+        expect(message.headers.getNames(), 'to equal', ['From', 'To']);
+        expect(message.headers.getNamesLowerCase(), 'to equal', ['from', 'to']);
     });
 
     it('should support reading a Buffer instance with iso-8859-1 chars', function () {
@@ -121,7 +122,8 @@ describe('Message', function () {
             "..."
         ].join('\r\n'), 'utf-8'));
 
-        expect(message.headers.getNames(), 'to equal', ['content-type', 'content-transfer-encoding', 'subject', 'from', 'message-id', 'date', 'to', 'mime-version']);
+        expect(message.headers.getNames(), 'to equal', ['Content-Type', 'Content-Transfer-Encoding', 'Subject', 'From', 'Message-Id', 'Date', 'To', 'Mime-Version']);
+        expect(message.headers.getNamesLowerCase(), 'to equal', ['content-type', 'content-transfer-encoding', 'subject', 'from', 'message-id', 'date', 'to', 'mime-version']);
         expect(message.headers.get('Content-Type'), 'to equal', 'multipart/mixed;\tboundary=Apple-Mail-589ECA5D-7F89-4C39-B7B7-7FD03E6333CD');
         expect(message.headers.get('content-transfer-encoding'), 'to equal', '7bit');
         expect(message.headers.get('Subject'), 'to equal', 'Foobar 123');


### PR DESCRIPTION
Hey,

This probably needs a little more work, but wanted to get started right away.

This commit adds a dictionary that stores the original casing headers were supplied with. `getNames()` is altered to pull those out, but other places accessing headers are forced to use an explicit lowercase version of the function to avoid behavioural change.

Two things I'm aware may need changing:
* the name of the extra dictionary (currently `namesWithCase`)
* whether `getNamesLowerCase()` should be exposed

Cheers, Alex.